### PR TITLE
Fixing Typo in 04 Cancel Orders.html Docs

### DIFF
--- a/02 Writing Algorithms/02 User Guides/03 Algorithm Reference/07 Trading and Orders/04 Cancel Orders.html
+++ b/02 Writing Algorithms/02 User Guides/03 Algorithm Reference/07 Trading and Orders/04 Cancel Orders.html
@@ -10,7 +10,7 @@ var ticket = LimitOrder("SPY", 100, 221.05, tag: "SPY Trade to Cancel");
 var response = ticket.Cancel();
 
 // Use order response object to read status
-if (response.IsSuccessful) {
+if (response.IsSuccess) {
        Debug("Order successfully canceled");
 }
 </pre>
@@ -21,7 +21,7 @@ ticket = self.LimitOrder("SPY", 100, 221.05, False, "SPY Trade to Cancel")
 response = ticket.Cancel("Canceled SPY Trade")
 
 # Use order response object to read status
-if response.IsSuccessful:
+if response.IsSuccess:
      self.Debug("Order successfully canceled")
 </pre>
 </div>


### PR DESCRIPTION
The docs currently have response.IsSuccessful when the actual OrderResponse API indicates it should be IsSuccess.
Currently on QC if someone runs the current docs code, they will get an error:
"OrderResponse does not have attribute IsSuccessful"